### PR TITLE
Added SpliX driver to support Samsung printers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	python-cups \
 	openprinting-ppds \
 	printer-driver-gutenprint \
+	printer-driver-splix \
 	&& rm -rf /var/lib/apt/lists/*
 
 # This will use port 631


### PR DESCRIPTION
SpliX is a set of CUPS printer drivers for SPL (Samsung Printer Language) printers. It supports various Samsung, Xerox, Dell, Toshiba and Lexmark printers. For full list of supported devices see [official pages](http://splix.sourceforge.net/).

I have tested this with my Samsung ML-1630W Series printer.